### PR TITLE
Dodge yarn & nyc incompatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "preversion": "git checkout master",
     "test": "mocha test.js --reporter=dot",
     "test:ci": "yarn run lint && yarn run test:coverage && yarn run coverage",
-    "test:coverage": "nyc yarn run test"
+    "test:coverage": "nyc npm run test"
   },
   "devDependencies": {
     "@articulate/spy": "^0.0.1",


### PR DESCRIPTION
Dodge https://github.com/yarnpkg/yarn/issues/6746 by invoking `nyc` with `npm` & not `yarn`. Fixes problems with CI.